### PR TITLE
Added weight converter

### DIFF
--- a/Weight-Converter-GUI/README.md
+++ b/Weight-Converter-GUI/README.md
@@ -1,0 +1,113 @@
+# Weight Converter GUI
+
+## Description
+
+I have created a GUI based weight converter that accepts a kilogram input value and converts that value to Carat, Gram, Ounce, Pound, Quintal and Tonne (i.e. in decreasing order) when the user clicks the Convert button.
+
+</br>
+
+## Step 1: Creating a window Using Tk
+
+The first step of any GUI is to create a window on which to begin placing components.
+
+We first import everything from the `tkinter` module. We then create a variable called root which is of type `Tk()`. This will be the main window on which we place components later on. The title of the window is then set by calling the `title` function. Finally, the `mainloop()` function is called on root.
+
+</br>
+
+## Step 2: Adding a widget using grid
+
+We can now start adding components, or widgets, to the window. The first widget we shall add will be `Label` widget. The basic construction of a `Label` widget is:
+
+```
+Label(<parent>, text=<text>)
+```
+
+Where `<parent>` is the parent object and `<text>` is a string which will be the text displayed. We will also need to add the `Label` to the grid and provide a column and row on which to place the widget on the grid.
+
+```
+l1.grid(row = 1, column = 1)
+```
+
+Now that we want to start placing widgets on a grid, the `Label` we have just created needs to be at column 1, row 1. Thus, when we place the Label on the grid, we provide the attributes column = 1 and row = 1.
+
+This might not look as one would expect. The `Label` we have created is on the far left. The reason for this is because when the widgets are placed on the grid, any empty columns and rows are left empty without any indication of their existence. This means that, although the `Label` is actually in column 2, row 0, this will not be visually apparent until we add more widgets in the surrounding area.
+
+</br>
+
+## Step 3: Spanning widgets over multiple rows and columns
+
+We can span several rows and columns of the grid. To achieve this behaviour, use the columnspan and rowspan attributes when placing a widget on the grid.
+
+```
+button.grid(row = 2, column = 2, columnspan = 2, rowspan = 2)
+```
+
+This code will place `Button` on the grid with the top corner at (2, 2) and spanning 2 columns, and 2 rows.
+
+</br>
+
+## Adding More Widgets
+
+The `tkinter` module provides 11 different widgets, and there are an additional 6 widgets in the [tkinter.ttk](https://docs.python.org/3/library/tkinter.ttk.html) module. We will only need a few of these to complete our GUI, but the basic use of these widgets is the same.
+
+</br>
+
+### Entry
+
+The `Entry` widget is used to allow the user to enter text. We will use the Entry widget for both the user input, and the output.
+
+Basic `Entry` widgets are created in the following form:
+
+```
+Entry(<parent>, textvariable=<variable>)
+```
+
+Where `<parent>` is the container of the widget, and `<variable>` is a variable which will be bound to the widget. Not all widgets have the option to bind a variable to them.
+
+When a variable is bound to an `Entry` widget, that variable will always be the value of the text inside the widget and hence the user's input. There are 4 possible types of variable which can be bound to widgets, `StringVar()`, `IntVar()`, `DoubleVar()` and `BooleanVar()`. Of which, not all types can always be used for all widgets.
+
+```
+t1.configure(state='disabled')
+```
+
+However, we will pass an additional attribute to the constructor of Entry, called `state`. The `state` attribute can take several forms including "active", "disabled", "pressed" and "selected", which define the current state of a widget. For the output Entry we will set its state to "disabled" to prevent the user from editing its contents.
+
+```
+t1.configure(state = 'normal')
+```
+
+This code would go in the callback for the event that will cause the Button to be enabled.
+
+```
+t1.delete("1.0", END)
+```
+
+This will delete from postion 0 till end.
+
+</br>
+
+### Button
+
+Next we will add a Button to our GUI. Button widgets are constructed in the following way:
+
+```
+Button(<parent>, text=<text>, command=<function>)
+```
+
+Where <function> in the command attribute is the action taken when the Button is pressed.
+
+</br>
+
+## Additional feature:
+
+### Exception Handling -
+
+The `try` block lets you test a block of code for errors. The `except` block lets you handle the error.
+
+Here, whenever a user enters any other value (i.e. alphabets, symbols etc.) instead of the interger or float(decimal) value than it will show a message saying "Invalid input" in the textbox.
+
+</br>
+
+## Output:
+
+![wc](https://user-images.githubusercontent.com/73488906/112635679-1f6b5880-8e62-11eb-9b6b-8779f303defd.png)

--- a/Weight-Converter-GUI/weight_con_gui.py
+++ b/Weight-Converter-GUI/weight_con_gui.py
@@ -34,12 +34,12 @@ def WeightConv():
         kilograms = float(e1.get())
 
         # insert the output in textboxes correct upto 2 places after decimal
-        t1.insert(END, "%.2f Carat" % (kilograms * 5000))
-        t2.insert(END, "%.2f Gram" % (kilograms * 1000))
-        t3.insert(END, "%.2f Ounce" % (kilograms * 35.274))
-        t4.insert(END, "%.2f Pound" % (kilograms * 2.20462))
-        t5.insert(END, "%.2f Quintal" % (kilograms * 0.01))
-        t6.insert(END, "%.2f Tonne" % (kilograms * 0.001))
+        t1.insert(END, "%.2f" % (kilograms * 5000))
+        t2.insert(END, "%.2f" % (kilograms * 1000))
+        t3.insert(END, "%.2f" % (kilograms * 35.274))
+        t4.insert(END, "%.2f" % (kilograms * 2.20462))
+        t5.insert(END, "%.2f" % (kilograms * 0.01))
+        t6.insert(END, "%.2f" % (kilograms * 0.001))
 
     # if blank or invalid input is given then exception is thrown
     except ValueError:
@@ -89,6 +89,24 @@ t5l5.grid(row = 8, column = 1, columnspan=1)
 
 t6l6 = Label(root, text = "kg to t : ")
 t6l6.grid(row = 9, column = 1, columnspan=1)
+
+t1r1 = Label(root, text = "Carat")
+t1r1.grid(row = 4, column = 4, columnspan=1)
+
+t2r2 = Label(root, text = "Gram")
+t2r2.grid(row = 5, column = 4, columnspan=1)
+
+t3r3 = Label(root, text = "Ounce")
+t3r3.grid(row = 6, column = 4, columnspan=1)
+
+t4r4 = Label(root, text = "Pound")
+t4r4.grid(row = 7, column = 4, columnspan=1)
+
+t5r5 = Label(root, text = "Quintal")
+t5r5.grid(row = 8, column = 4, columnspan=1)
+
+t6r6 = Label(root, text = "Tonne")
+t6r6.grid(row = 9, column = 4, columnspan=1)
 
 # creating textbox and defining grid to show output
 t1 = Text(root, height = 1, width = 20)

--- a/Weight-Converter-GUI/weight_con_gui.py
+++ b/Weight-Converter-GUI/weight_con_gui.py
@@ -1,0 +1,119 @@
+# import libraries
+from tkinter import *
+
+# initialized window
+root = Tk()
+root.geometry('480x350')
+root.resizable(0,0)
+root.title('Weight Converter')
+
+# defining the function for converting weights
+def WeightConv():
+
+    # making textbox user-friendly that is editable
+    t1.configure(state = 'normal')
+    t1.delete("1.0", END)
+
+    t2.configure(state = 'normal')
+    t2.delete("1.0", END)
+
+    t3.configure(state = 'normal')
+    t3.delete("1.0", END)
+
+    t4.configure(state='normal')
+    t4.delete("1.0", END)
+
+    t5.configure(state='normal')
+    t5.delete("1.0", END)
+
+    t6.configure(state='normal')
+    t6.delete("1.0", END)
+
+    # exception handling
+    try:
+        kilograms = float(e1.get())
+
+        # insert the output in textboxes correct upto 2 places after decimal
+        t1.insert(END, "%.2f Carat" % (kilograms * 5000))
+        t2.insert(END, "%.2f Gram" % (kilograms * 1000))
+        t3.insert(END, "%.2f Ounce" % (kilograms * 35.274))
+        t4.insert(END, "%.2f Pound" % (kilograms * 2.20462))
+        t5.insert(END, "%.2f Quintal" % (kilograms * 0.01))
+        t6.insert(END, "%.2f Tonne" % (kilograms * 0.001))
+
+    # if blank or invalid input is given then exception is thrown
+    except ValueError:
+        t1.insert(END, "  ~ Invalid input ~  ")
+        t2.insert(END, "  ~ Invalid input ~  ")
+        t3.insert(END, "  ~ Invalid input ~  ")
+        t4.insert(END, "  ~ Invalid input ~  ")
+        t5.insert(END, "  ~ Invalid input ~  ")
+        t6.insert(END, "  ~ Invalid input ~  ")
+
+    # making textbox uneditable
+    t1.configure(state='disabled')
+    t2.configure(state='disabled')
+    t3.configure(state='disabled')
+    t4.configure(state='disabled')
+    t5.configure(state='disabled')
+    t6.configure(state='disabled')
+
+# creating a label to display
+l1 = Label(root, text = "Enter the weight in kilograms (kg) : ")
+l1.grid(row = 1, column = 1,columnspan = 2)
+value = StringVar()
+
+# creating a entry box for input
+e1 = Entry(root, textvariable=value)
+e1.grid(row = 1, column = 3,columnspan = 2)
+
+# create a button for conversion
+button = Button(root, text = "Convert", command = WeightConv)
+button.grid(row = 2, column = 2, columnspan = 2, rowspan = 2)
+
+# make labels for textbox
+t1l1 = Label(root, text = "kg to ct : ")
+t1l1.grid(row = 4, column = 1, columnspan=1)
+
+t2l2 = Label(root, text = "kg to g : ")
+t2l2.grid(row = 5, column = 1, columnspan=1)
+
+t3l3 = Label(root, text = "kg to oz : ")
+t3l3.grid(row = 6, column = 1, columnspan=1)
+
+t4l4 = Label(root, text = "kg to lb : ")
+t4l4.grid(row = 7, column = 1, columnspan=1)
+
+t5l5 = Label(root, text = "kg to q : ")
+t5l5.grid(row = 8, column = 1, columnspan=1)
+
+t6l6 = Label(root, text = "kg to t : ")
+t6l6.grid(row = 9, column = 1, columnspan=1)
+
+# creating textbox and defining grid to show output
+t1 = Text(root, height = 1, width = 20)
+t1.grid(row = 4, column = 2, columnspan = 2)
+
+t2 = Text(root, height = 1, width = 20)
+t2.grid(row = 5, column = 2, columnspan = 2)
+
+t3 = Text(root, height = 1, width = 20)
+t3.grid(row = 6, column = 2, columnspan = 2)
+
+t4 = Text(root, height = 1, width = 20)
+t4.grid(row = 7, column = 2, columnspan = 2)
+
+t5 = Text(root, height = 1, width = 20)
+t5.grid(row = 8, column = 2, columnspan = 2)
+
+t6 = Text(root, height = 1, width = 20)
+t6.grid(row = 9, column = 2, columnspan = 2)
+
+# making blank spaces in GUI
+for r in range(10):
+    root.grid_rowconfigure(r,minsize = 30)
+for c in range(6):
+    root.grid_columnconfigure(c,minsize = 50)
+
+# infinite loop to run program
+root.mainloop()


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change.
Happy Contributing!
-->

# Description
I have created a GUI based weight converter that accepts a kilogram input value and converts that value to Carat, Gram, Ounce, Pound, Quintal and Tonne when the user clicks the Convert button.

I have arranged weight conversions in decreasing order like starting from Carat to Tonne(mentioned above).

Output of the code:

![wc](https://user-images.githubusercontent.com/73488906/112635679-1f6b5880-8e62-11eb-9b6b-8779f303defd.png)

One more feature: It is editable :)

## Fixes #740 Weight Converter GUI

## Have you read the [Contributing Guidelines on Pull Requests](https://github.com/avinashkranjan/Amazing-Python-Scripts/blob/master/CONTRIBUTING.md)?

- [x] Yes
- [ ] No

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines(Clean Code) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have created a helpful and easy to understand `README.md`
- [ ] My documentation follows [`Template for README.md`](https://github.com/avinashkranjan/Amazing-Python-Scripts/blob/master/Template%20for%20README.md)
- [x] My changes generate no new warnings
- [x] I have added tests/screenshots(above in description) that prove my feature is effective or that my feature works.
