### PR TITLE
'Fixed_half_input_statement'

### DIFF
--- a/Age-Calculator-GUI/age_calc_gui.py
+++ b/Age-Calculator-GUI/age_calc_gui.py
@@ -53,13 +53,13 @@ class App:
             try:
                 year = int(self.yearEntry.get())
                 if today.year - year < 0:
-                    self.statement = tk.Label(text=f"{nameValue.get()}'s age cannot be negative.", font="courier 10", bg="lightblue")
+                    self.statement = tk.Label(text=f"{nameValue.get()}'s age\n cannot be negative.", font="courier 10", bg="lightblue")
                     self.statement.grid(row=6, column=1, pady=15)
                     return False
                 else:
                     return True
             except Exception as e:
-                self.statement = tk.Label(text=f"{nameValue.get()}'s birth year cannot parse to int.", font="courier 10", bg="lightblue")
+                self.statement = tk.Label(text=f"{nameValue.get()}'s birth year\n cannot parse to int.", font="courier 10", bg="lightblue")
                 self.statement.grid(row=6, column=1, pady=15)
                 return False
 
@@ -69,13 +69,13 @@ class App:
             try:
                 month = int(self.monthEntry.get())
                 if month < 0 or month > 12:
-                    self.statement = tk.Label(text=f"{nameValue.get()}'s birth month is outside 1-12.", font="courier 10", bg="lightblue")
+                    self.statement = tk.Label(text=f"{nameValue.get()}'s birth month\n is outside 1-12.", font="courier 10", bg="lightblue")
                     self.statement.grid(row=6, column=1, pady=15)
                     return False
                 else:
                     return True
             except Exception as e:
-                self.statement = tk.Label(text=f"{nameValue.get()}'s birth month cannot parse to int.", font="courier 10", bg="lightblue")
+                self.statement = tk.Label(text=f"{nameValue.get()}'s birth month\n cannot parse to int.", font="courier 10", bg="lightblue")
                 self.statement.grid(row=6, column=1, pady=15)
                 return False
         
@@ -85,13 +85,13 @@ class App:
             try:
                 day = int(self.dayEntry.get())
                 if day < 0 or day > 31:
-                    self.statement = tk.Label(text=f"{nameValue.get()}'s birth day is outside 1-31.", font="courier 10", bg="lightblue")
+                    self.statement = tk.Label(text=f"{nameValue.get()}'s birth day is\n outside 1-31.", font="courier 10", bg="lightblue")
                     self.statement.grid(row=6, column=1, pady=15)
                     return False
                 else:
                     return True
             except Exception as e:
-                self.statement = tk.Label(text=f"{nameValue.get()}'s birth month cannot parse to int.", font="courier 10", bg="lightblue")
+                self.statement = tk.Label(text=f"{nameValue.get()}'s birth month\n cannot parse to int.", font="courier 10", bg="lightblue")
                 self.statement.grid(row=6, column=1, pady=15)
                 return False
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change.
Happy Contributing!
-->

# Description

Fixed the half-output statement. Reading this half statement user doesn't get to know what mistake he/she has done.  Initially, the script shows the output like this:-

![Screenshot (76)](https://github.com/avinashkranjan/Amazing-Python-Scripts/assets/122978299/1b73db57-5384-42c8-815f-9db45717e94f)

But now after fixing it looks like this:-

![Screenshot (77)](https://github.com/avinashkranjan/Amazing-Python-Scripts/assets/122978299/3fddcb4d-acc0-405b-bf0f-4b84e188cb38)
Now the user will get to know what mistake he/she has done while giving the inputs and also I've done this for all the output statements ensuring a good user experience!


## Fixes #1450 


## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:  
- [x] My code follows the style guidelines(Clean Code) of this project 
- [x] I have performed a self-review of my own code 
- [x] I have commented my code, particularly in hard-to-understand areas 
- [ ] I have created a helpful and easy to understand `README.md` 
- [x] My documentation follows [`Template for README.md`](https://github.com/avinashkranjan/Amazing-Python-Scripts/blob/master/Template%20for%20README.md) 
- [ ] I have added the project meta data in the PR template. 
- [ ] I have created the ``requirements.txt`` file if needed.

## Project Metadata

NONE

Category: 
- [x] Calculators 
- [ ] AI/ML 
- [ ] Scrappers 
- [ ] Social_Media 
- [ ] PDF 
- [ ] Image_Processing 
- [ ] Video_Processing 
- [ ] Games 
- [ ] Networking 
- [ ] OS_Utilities 
- [ ] Automation 
- [ ] Cryptography 
- [ ] Computer_Vision 
- [x] Fun 
- [ ] Others

Title: \<Amazing-Python-Scripts>

Folder: \<Age-Calculator-GUI>

Requirements: \<NONE\>

Script: \<age_calc_gui>

Arguments: \<User's name-2003-23-23>

Contributor: \<Shiv-Expert2503\>

Description: \<Fixed half input statement which is sometimes frustrating to the user\>