### PR TITLE
'Fixed_day_section'

### DIFF
--- a/Age-Calculator-GUI/age_calc_gui.py
+++ b/Age-Calculator-GUI/age_calc_gui.py
@@ -91,7 +91,7 @@ class App:
                 else:
                     return True
             except Exception as e:
-                self.statement = tk.Label(text=f"{nameValue.get()}'s birth month\n cannot parse to int.", font="courier 10", bg="lightblue")
+                self.statement = tk.Label(text=f"{nameValue.get()}'s birth day\n cannot parse to int.", font="courier 10", bg="lightblue")
                 self.statement.grid(row=6, column=1, pady=15)
                 return False
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change.
Happy Contributing!
-->

# Description
Before, the Python script written in the age calculator shows the month parse error statement for the day section also. Which must not be there. The error is like this in day section also:-
![Screenshot (85)](https://github.com/avinashkranjan/Amazing-Python-Scripts/assets/122978299/b2c1e4d0-99c8-4654-b29a-1bf0b9b1d9d2)

Now after fixing, the output is as follows:-
![Screenshot (1)](https://github.com/avinashkranjan/Amazing-Python-Scripts/assets/122978299/5cbd904c-9c99-4d9c-ab01-9b937354870c)


## Fixes #1598 

<!-- Replace `issue_no` with the issue number which is fixed in this PR -->

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines(Clean Code) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

## Project Metadata

NONE

Category:
- [x] Calculators
- [ ] AI/ML
- [ ] Scrappers
- [ ] Social_Media
- [ ] PDF
- [ ] Image_Processing
- [ ] Video_Processing
- [ ] Games
- [ ] Networking
- [ ] OS_Utilities
- [ ] Automation
- [ ] Cryptography
- [ ] Computer_Vision
- [ ] Fun
- [ ] Others

Title: \<Amazing-Python-Scripts>

Folder: \<Age-Calculator-GUI>

Requirements: \<NONE\>

Script: \<age_calc_gui>

Arguments: \<User's name-2003-12-any_non_integeral value>

Contributor: \<Shiv-Expert2503\>

Description: \<Fixed month parse error in day section\>
